### PR TITLE
Remove reference to local html files.

### DIFF
--- a/web-viewer.md
+++ b/web-viewer.md
@@ -10,7 +10,7 @@
 
 | Property | Description |
 | :--- | :--- |
-| URL | Accepts website or image urls that must include `https://` or `http://`. Can also accept `.html` files that have been uploaded to the app \(great for offline use\) |
+| URL | Accepts website or image urls that must include `https://` or `http://`. |
 
 The Web Viewer currently permits full-screen viewing of videos on iOS only
 


### PR DESCRIPTION
The rendering of local files in the Web Viewer doesn't work on all platforms or for all the sorts of content that might be in the page.
It was always just a convenient accident that it worked at all ;-)